### PR TITLE
Bug with user-defined functions fixed

### DIFF
--- a/src/main/java/Backend/ExpressionBuilders/RealValuedExpressionBuilder.java
+++ b/src/main/java/Backend/ExpressionBuilders/RealValuedExpressionBuilder.java
@@ -37,7 +37,6 @@ public class RealValuedExpressionBuilder extends ExpressionBuilder<RealValuedExp
     }
 
     // Below should construct functions (including build-in and user-defined functions)
-    // TODO: Future: Include User-Defined Functions once we made it clear how we want to treat them. E.g. Where to store them and how to handle them...
     public RealValuedExpressionBuilder constructExpression(String funcName, RealValuedExpressionBuilder[] inputs,
                                                            Map<String, FunctionExpression> funcMap)
             throws EmptyBuilderException {
@@ -47,9 +46,13 @@ public class RealValuedExpressionBuilder extends ExpressionBuilder<RealValuedExp
             inputExpressions[i] = inputs[i].build();
         }
 
-        FunctionExpression func = funcMap.get(funcName);
-        func.setInputs(inputExpressions);
-        this.expr = func;
+        FunctionExpression oldFunc = funcMap.get(funcName);
+
+        // We create a new copy of the function other the set inputs below would overwrite the original values
+        FunctionExpression newFunc = new CustomFunctionExpression(funcName, oldFunc.getVariables(), oldFunc);
+
+        newFunc.setInputs(inputExpressions);
+        this.expr = newFunc;
         return this;
     }
 }

--- a/src/main/java/Frontend/CommandLineInterface.java
+++ b/src/main/java/Frontend/CommandLineInterface.java
@@ -47,7 +47,7 @@ public class CommandLineInterface {
             cliHelper.trySettingOrigin(cliHelper, userInputs, axes, auc);
         }
 
-        ExpressionReader er = new ExpressionReader(auc.getNamedFunctions(axes));
+        ExpressionReader er = new ExpressionReader(axes);
         Grapher grapher = new Grapher(axes);
         List<String[]> equationsAndDomains = cliHelper.findAllEquations(args);
         cliHelper.tryInterpretingInput(axes, auc, er, equationsAndDomains);


### PR DESCRIPTION
Bug caused user defined functions to be overwritten. For example defining `f(x) = sin(x)` and then `g(x) = f(x^2)` would cause `f` to be interpreted as `sin(x^2)` rather than `sin(x)`