### PR TITLE
CLI: add "-name" command specifying the name of the image

### DIFF
--- a/src/main/java/Frontend/CLIHelper.java
+++ b/src/main/java/Frontend/CLIHelper.java
@@ -116,8 +116,8 @@ public class CLIHelper {
     public void trySavingImage(int[] pixels, ArrayList<String> userInputs) {
         try {
             String name;
-            if (userInputs.contains("-save")) {
-                name = getCommandArgument("-save", userInputs) + ".png";
+            if (userInputs.contains("-name")) {
+                name = getCommandArgument("-name", userInputs) + ".png";
             } else {
                 name = "graph.png";
             }

--- a/src/main/java/Frontend/CommandLineInterface.java
+++ b/src/main/java/Frontend/CommandLineInterface.java
@@ -30,7 +30,8 @@ public class CommandLineInterface {
 
         // An array of strings containing accepted Commands. This is open to extension as other parts
         // of the code become available to be merged into this CLI.
-        String[] acceptedCommands = {"-eq", "-dim", "-graph", "-save", "-load", "-pos", "-domain", "-interactive"}; // TODO: Move to Constants?
+        String[] acceptedCommands = {"-eq", "-dim", "-graph", "-save", "-load",
+                "-pos", "-domain", "-interactive", "-name"}; // TODO: Move to Constants?
 
         if (!cliHelper.checkValidInput(acceptedCommands, userInputs)) {
             return;
@@ -51,11 +52,12 @@ public class CommandLineInterface {
         List<String[]> equationsAndDomains = cliHelper.findAllEquations(args);
         cliHelper.tryInterpretingInput(axes, auc, er, equationsAndDomains);
         int[] graphedImage = cliHelper.tryGraphingImage(userInputs, grapher);
-        cliHelper.trySavingImage(graphedImage, userInputs);
 
         if (userInputs.contains("-interactive")) {
             GUI gui = (GUI)(new GLGUI(grapher, 512));
             cliHelper.startGUI(userInputs, gui);
+        } else {
+            cliHelper.trySavingImage(graphedImage, userInputs);
         }
 
         if (userInputs.contains("-save")) {


### PR DESCRIPTION
This commit also includes the new logic that the image should only be saved if and only if "-interactive" was not called. The default is "graph.png", and otherwise the user has to specify the name of the image by the "-name" command.