### PR TITLE
CLI: modified the save logic

### DIFF
--- a/src/main/java/Frontend/CommandLineInterface.java
+++ b/src/main/java/Frontend/CommandLineInterface.java
@@ -62,11 +62,13 @@ public class CommandLineInterface {
         cliHelper.tryInterpretingInput(axes, auc, er, equationsAndDomains);
         int[] graphedImage = cliHelper.tryGraphingImage(userInputs, grapher);
 
+        if (userInputs.contains(cliHelper.graphCommand)) {
+            cliHelper.trySavingImage(graphedImage, userInputs);
+        }
+
         if (userInputs.contains(cliHelper.interactiveCommand)) {
             GUI gui = new GLGUI(grapher, cliHelper.getCustomSize(userInputs));
             cliHelper.startGUI(userInputs, gui);
-        } else {
-            cliHelper.trySavingImage(graphedImage, userInputs);
         }
 
         if (userInputs.contains(cliHelper.saveCommand)) {


### PR DESCRIPTION
From now on, the image will be saved when -graph command is called, regardless of whether the user typed -interactive command or not